### PR TITLE
[PLATFORM-3432] Fix broken build due to logout endpoint

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -178,6 +178,11 @@ const getCookies = (req: FastifyRequest): Record<string, string> => {
     return parseCookies(cookies)
 }
 
+const setClearCookies = (reply: FastifyReply) => {
+    const clearedCookies = createTokenCookies('', '')
+    reply.header('Set-Cookie', clearedCookies)
+}
+
 const validateDPoP = (req: FastifyRequest): string => {
     if (!USE_DPOP)
         return ''
@@ -505,7 +510,7 @@ const logoutEndpoint = async (req: FastifyRequest, reply: FastifyReply) => {
     const { nonce } = req.body as { nonce?: string }
 
     await logoutUser(nonce || '')
-    setTokenCookies(reply, '', '')
+    setClearCookies(reply)
 
     return reply.send({loggedOut: true})
 }


### PR DESCRIPTION
PLATFORM-3432
---

Some functionality we were using to clear cookies for our own implementation of a logout endpoint was removed from upstream in a recent version. This was causing the npm build to fail. This PR refactors this code so build succeeds and so we can continue supporting our own logout endpoint until we have the time to update clients to use the new logout endpoint provided by upstream.